### PR TITLE
added: common constraint features

### DIFF
--- a/docsrc/srcs/modules.rst
+++ b/docsrc/srcs/modules.rst
@@ -44,6 +44,7 @@ CyObjects
     cymel.core.cyobjects.shape
     cymel.core.cyobjects.transform
     cymel.core.cyobjects.transform_c
+    cymel.core.cyobjects.constraint
 
     cymel.core.typeinfo
     cymel.core.typeregistry

--- a/python/cymel/core/cyobjects/__init__.py
+++ b/python/cymel/core/cyobjects/__init__.py
@@ -15,6 +15,7 @@ from .dagnode import *
 from .transform import *
 from .shape import *
 from .reference import *
+from .constraint import *
 
 def _all():
     from types import ModuleType

--- a/python/cymel/core/cyobjects/constraint.py
+++ b/python/cymel/core/cyobjects/constraint.py
@@ -9,19 +9,8 @@ from __future__ import print_function
 from ...common import *
 from ..typeregistry import nodetypes, _FIX_SLOTS
 from .cyobject import CyObject
-import maya.api.OpenMaya as _api2
-import itertools
 
 __all__ = ['Constraint']
-
-_from_iterable = itertools.chain.from_iterable
-
-_MFn_kDagNode = _api2.MFn.kDagNode
-_MFn_kTransform = _api2.MFn.kTransform
-_MFn_kConstraint = _api2.MFn.kConstraint
-_2_MDagPath = _api2.MDagPath
-_2_getAllPathsTo = _2_MDagPath.getAllPathsTo
-_2_NullObj = _api2.MObject.kNullObj
 
 
 #------------------------------------------------------------------------------

--- a/python/cymel/core/cyobjects/constraint.py
+++ b/python/cymel/core/cyobjects/constraint.py
@@ -46,10 +46,9 @@ class Constraint(nodetypes.parentBasicNodeClass('constraint')):
 
         :rtype: list
         """
-        name = self.name()
         return list(
             map(
-                lambda x: CyObject('{}.{}'.format(name, x)),
+                self.plug_,
                 self._cmd(self, weightAliasList=True, q=True)
             )
         )

--- a/python/cymel/core/cyobjects/constraint.py
+++ b/python/cymel/core/cyobjects/constraint.py
@@ -23,8 +23,6 @@ _2_MDagPath = _api2.MDagPath
 _2_getAllPathsTo = _2_MDagPath.getAllPathsTo
 _2_NullObj = _api2.MObject.kNullObj
 
-# _constraint = cmds.constraint
-
 
 #------------------------------------------------------------------------------
 class Constraint(nodetypes.parentBasicNodeClass('constraint')):

--- a/python/cymel/core/cyobjects/constraint.py
+++ b/python/cymel/core/cyobjects/constraint.py
@@ -21,16 +21,18 @@ class Constraint(nodetypes.parentBasicNodeClass('constraint')):
     if _FIX_SLOTS:
         __slots__ = ('_cmd',)
 
-    def __init__(self, *args, **kwargs):
-        super(Constraint, self).__init__()
-        self._cmd = getattr(cmds, self.type())
+    @classmethod
+    def newObject(cls, data):
+        obj = super(Constraint, cls).newObject(data)
+        obj._cmd = getattr(cmds, obj.type())
+        return obj
 
     def _getTargetList(self):
         """Return the list of target objects.
 
         :rtype: list[str]
         """
-        return self._cmd(self, targetList=True, q=True)
+        return self._cmd(self, targetList=True, q=True) or []
 
     def getTargetList(self):
         """Return the list of target objects.
@@ -44,36 +46,55 @@ class Constraint(nodetypes.parentBasicNodeClass('constraint')):
         Returns the names of the attributes that control the weight of the target objects.
         Aliases are returned in the same order as the targets are returned by the targetList flag
 
-        :rtype: list
+        :rtype: list[str]
+        """
+        return self._cmd(self, weightAliasList=True, q=True) or []
+
+    def getWeightPlugList(self):
+        """
+        Returns the plug that control the weight of the target objects.
+        Plugs are returned in the same order as the targets are returned by the targetList flag
+
+        :rtype: list[plug]
         """
         return list(
             map(
                 self.plug_,
-                self._cmd(self, weightAliasList=True, q=True)
+                self._cmd(self, weightAliasList=True, q=True) or []
             )
         )
 
     def setWeight(self, weight, *targetObjects):
         """
         Sets the weight value for the specified targetObject(s).
+        if targetObjects are not provided, this will set weights for all targets
+
+        :param float weight: weight value to set for given target
+        :param targetObjects: target nodes of this constraint
         """
         if targetObjects:
             self._cmd(targetObjects + (self,), e=True, weight=weight)
         else:
-            name = self.name()
-            self._cmd(self._getTargetList() + [name], e=True, weight=weight)
+            targetObjects = self._getTargetList()
+            if targetObjects:
+                self._cmd(targetObjects + [self.name_()], e=True, weight=weight)
 
     def getWeight(self, *targetObjects):
         """
         Returns the weight value for the specified targetObject(s).
+        if targetObjects are not provided, this will get weights of all targets
 
-        :rtype: float
+        :param targetObjects: target nodes of this constraint
+
+        :rtype: float or list[float]
         """
         if targetObjects:
             return self._cmd(targetObjects + (self,), q=True, weight=True)
         else:
-            name = self.name()
-            return self._cmd(self._getTargetList() + [name], q=True, weight=True)
+            targetObjects = self._getTargetList()
+            if targetObjects:
+                return self._cmd(targetObjects + [self.name_()], q=True, weight=True)
+            return targetObjects
 
 
 nodetypes.registerNodeClass(Constraint, 'constraint')

--- a/python/cymel/core/cyobjects/constraint.py
+++ b/python/cymel/core/cyobjects/constraint.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+u"""
+:mayanode:`constraint`
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from ...common import *
+from ..typeregistry import nodetypes, _FIX_SLOTS
+from .cyobject import CyObject
+import maya.api.OpenMaya as _api2
+import itertools
+
+__all__ = ['Constraint']
+
+_from_iterable = itertools.chain.from_iterable
+
+_MFn_kDagNode = _api2.MFn.kDagNode
+_MFn_kTransform = _api2.MFn.kTransform
+_MFn_kConstraint = _api2.MFn.kConstraint
+_2_MDagPath = _api2.MDagPath
+_2_getAllPathsTo = _2_MDagPath.getAllPathsTo
+_2_NullObj = _api2.MObject.kNullObj
+
+# _constraint = cmds.constraint
+
+
+#------------------------------------------------------------------------------
+class Constraint(nodetypes.parentBasicNodeClass('constraint')):
+    u"""
+    :mayanode:`constraint`
+    """
+    if _FIX_SLOTS:
+        __slots__ = tuple()
+
+    def getTargetList(self):
+        """Return the list of target objects.
+
+        :rtype: list
+        """
+        inFunc = getattr(cmds, self.type())
+        return [CyObject(obj) for obj in inFunc(self, targetList=True, q=True)]
+
+    def getWeightAliasList(self):
+        """
+        Returns the names of the attributes that control the weight of the target objects.
+        Aliases are returned in the same order as the targets are returned by the targetList flag
+
+        :rtype: list
+        """
+        inFunc = getattr(cmds, self.type())
+        return [CyObject('{}.{}'.format(self.name(), obj)) for obj in inFunc(self, weightAliasList=True, q=True)]
+
+    def setWeight(self, weight, *targetObjects):
+        """
+        Sets the weight value for the specified targetObject(s).
+        """
+        inFunc = getattr(cmds, self.type())
+        if not targetObjects:
+            targetObjects = self.getTargetList()
+
+        constraintObj = self.constraintParentInverseMatrix.inputs()[0].node()
+        args = list(targetObjects) + [constraintObj]
+        return inFunc(*args, **{'edit': True, 'weight': weight})
+
+    def getWeight(self, *targetObjects):
+        """
+        Returns the weight value for the specified targetObject(s).
+
+        :rtype: float
+        """
+        inFunc = getattr(cmds, self.type())
+        if not targetObjects:
+            targetObjects = self.getTargetList()
+
+        constraintObj = self.constraintParentInverseMatrix.inputs()[0].node()
+        args = list(targetObjects) + [constraintObj]
+        return inFunc(*args, **{'query': True, 'weight': True})
+
+
+nodetypes.registerNodeClass(Constraint, 'constraint')

--- a/test/cymel_test/__init__.py
+++ b/test/cymel_test/__init__.py
@@ -6,9 +6,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-# import sys, os
-#
-# sys.path.insert(0, os.path.join(__path__[0], '..', '..', 'python'))
 
 import unittest
 from cymel_test import (

--- a/test/cymel_test/__init__.py
+++ b/test/cymel_test/__init__.py
@@ -6,6 +6,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+# import sys, os
+#
+# sys.path.insert(0, os.path.join(__path__[0], '..', '..', 'python'))
+
 import unittest
 from cymel_test import (
     core, pyutils, utils,

--- a/test/cymel_test/core/__init__.py
+++ b/test/cymel_test/core/__init__.py
@@ -8,12 +8,14 @@ from __future__ import print_function
 import unittest
 from cymel_test.core import (
     cyobjects,
+    constraint,
 )
 
 
 def suite():
      return unittest.TestSuite((
         cyobjects.suite(),
+        constraint.suite(),
     ))
 
 

--- a/test/cymel_test/core/constraint.py
+++ b/test/cymel_test/core/constraint.py
@@ -16,13 +16,29 @@ class TestConstraints(unittest.TestCase):
     u"""
     Test of Constraint.
     """
-    def test_Constraint(self):
+
+    def setUp(self):
         cmds.file(f=True, new=True)
 
         # given
-        a = cmds.createNode('transform', ss=1)
-        b = cmds.createNode('transform', ss=1)
-        c = cmds.createNode('transform', ss=1)
+        self.a = cmds.createNode('transform', ss=1)
+        self.b = cmds.createNode('transform', ss=1)
+        self.c = cmds.createNode('transform', ss=1)
+
+    def test_Constraint_constraint_node_can_initialize_with_Constraint_class(self):
+        con = cmds.parentConstraint(self.a, self.b)[0]
+        conObj = cm.nt.Constraint(con)
+        self.assertIsInstance(
+            conObj,
+            cm.nt.Constraint
+        )
+
+    def test_Constraint(self):
+
+        # given
+        a = self.a
+        b = self.b
+        c = self.c
 
         for conType in [
             'parentConstraint',
@@ -35,6 +51,7 @@ class TestConstraints(unittest.TestCase):
             conName = conCmd(a, b, c)
             conObj = cm.O(conName[0])
             self._runAssertionsFor(conType, conObj)
+
             cmds.delete(conObj)
 
     def _runAssertionsFor(self, conType, conObj):

--- a/test/cymel_test/core/constraint.py
+++ b/test/cymel_test/core/constraint.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 u"""
-カスタムクラス関連のテスト。
+constraint related tests
 """
 from __future__ import print_function
 from __future__ import absolute_import

--- a/test/cymel_test/core/constraint.py
+++ b/test/cymel_test/core/constraint.py
@@ -33,6 +33,14 @@ class TestConstraints(unittest.TestCase):
             cm.nt.Constraint
         )
 
+    def test_Constraint_getWeight_returns_empty_list_if_target_doesnot_exists(self):
+        con = cmds.createNode('parentConstraint')
+        conObj = cm.nt.Constraint(con)
+        self.assertEqual(
+            conObj.getWeight(),
+            []
+        )
+
     def test_Constraint(self):
 
         # given
@@ -72,6 +80,15 @@ class TestConstraints(unittest.TestCase):
 
         # when
         aliases = conObj.getWeightAliasList()
+
+        # then
+        self.assertListEqual(
+            aliases,
+            ['transform1W0', 'transform2W1']
+        )
+
+        # when
+        aliases = conObj.getWeightPlugList()
 
         # then
         self.assertListEqual(

--- a/test/cymel_test/core/constraint.py
+++ b/test/cymel_test/core/constraint.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+u"""
+カスタムクラス関連のテスト。
+"""
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import sys
+import unittest
+import cymel.main as cm
+import maya.cmds as cmds
+
+
+class TestConstraints(unittest.TestCase):
+    u"""
+    Test of Constraint.
+    """
+    def test_Constraint(self):
+        cmds.file(f=True, new=True)
+
+        # given
+        a = cmds.createNode('transform', ss=1)
+        b = cmds.createNode('transform', ss=1)
+        c = cmds.createNode('transform', ss=1)
+
+        for conType in [
+            'parentConstraint',
+            'pointConstraint',
+            'orientConstraint',
+            'scaleConstraint',
+            'aimConstraint',
+        ]:
+            conCmd = getattr(cmds, conType)
+            conName = conCmd(a, b, c)
+            conObj = cm.O(conName[0])
+            self._runAssertionsFor(conType, conObj)
+            cmds.delete(conObj)
+
+    def _runAssertionsFor(self, conType, conObj):
+        # then
+        self.assertIsInstance(
+            conObj,
+            cm.nt.Constraint
+        )
+
+        # when
+        targets = conObj.getTargetList()
+
+        # then
+        self.assertListEqual(
+            targets,
+            [cm.nt.Transform('transform1'), cm.nt.Transform('transform2')]
+        )
+
+        # when
+        aliases = conObj.getWeightAliasList()
+
+        # then
+        self.assertListEqual(
+            aliases,
+            [cm.Plug('transform3_{}1.w0'.format(conType)), cm.Plug('transform3_{}1.w1'.format(conType))]
+        )
+
+        # when
+        conObj.setWeight(0.5)
+
+        # then
+        self.assertEqual(
+            cmds.getAttr('transform3_{}1.w0'.format(conType)),
+            0.5
+        )
+        self.assertEqual(
+            cmds.getAttr('transform3_{}1.w1'.format(conType)),
+            0.5
+        )
+
+        # when
+        conObj.setWeight(0.75, 'transform1')
+
+        # then
+        self.assertEqual(
+            cmds.getAttr('transform3_{}1.w0'.format(conType)),
+            0.75
+        )
+        self.assertEqual(
+            cmds.getAttr('transform3_{}1.w1'.format(conType)),
+            0.5
+        )
+
+        self.assertEqual(
+            conObj.getWeight(),
+            [0.75, 0.5]
+        )
+
+        self.assertEqual(
+            conObj.getWeight('transform1'),
+            0.75
+        )
+
+        self.assertEqual(
+            conObj.getWeight('transform2'),
+            0.5
+        )
+
+
+#------------------------------------------------------------------------------
+def suite():
+    return unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+
+def run(**kwargs):
+    unittest.TextTestRunner(**kwargs).run(suite())
+
+if __name__ == '__main__':
+    run(verbosity=2)


### PR DESCRIPTION
added following methods to constraint class
- getTargetList
- getWeightAliasList
- setWeight
- getWeight

these functions are tested for following constraint commands
- parentConstraint
- pointConstraint
- orientConstraint
- scaleConstraint
- aimConstraint

manual testing
```python
con = cmds.parentConstraint('transform1', 'transform2', 'transform3')[0]
conObj = cm.O(con)

conObj.getTargetList()
conObj.getWeightAliasList()
conObj.setWeight(0.5, 'transform1')
conObj.getWeight()
```